### PR TITLE
SBIR/LDRD experiment update (March 30-April 2, 2023)

### DIFF
--- a/startup/90-setup.py
+++ b/startup/90-setup.py
@@ -8,7 +8,55 @@ from bluesky.callbacks import LiveTable, LivePlot
 from bluesky.plans import list_scan
 import bluesky.plans as bp
 from bluesky.plan_stubs import mv
-from bluesky.plan_stubs import one_1d_step
+
+# The line above causes issues with bluesky-queueserver:
+# from bluesky.plan_stubs import one_1d_step
+
+# [E 2023-04-01 17:25:38,999 bluesky_queueserver.manager.worker] Failed to start RE Worker environment. Error while loading startup code: Failed to create description of plan 'one_1d_step': Parameter 'take_reading': The expression (<function trigger_and_read at 0x7ff0ae7ab640>) can not be evaluated with 'ast.literal_eval()': unsupported type of default value..
+# Traceback (most recent call last):
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2582, in convert_expression_to_string
+#     ast.literal_eval(s_value)
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/ast.py", line 64, in literal_eval
+#     node_or_string = parse(node_or_string.lstrip(" \t"), mode='eval')
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/ast.py", line 50, in parse
+#     return compile(source, filename, mode, flags,
+#   File "<unknown>", line 1
+#     <function trigger_and_read at 0x7ff0ae7ab640>
+#     ^
+# SyntaxError: invalid syntax
+
+# During handling of the above exception, another exception occurred:
+
+# Traceback (most recent call last):
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2717, in _process_plan
+#     default = convert_expression_to_string(p.default, expression_role="default value")
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2586, in convert_expression_to_string
+#     raise ValueError(
+# ValueError: The expression (<function trigger_and_read at 0x7ff0ae7ab640>) can not be evaluated with 'ast.literal_eval()': unsupported type of default value.
+
+# During handling of the above exception, another exception occurred:
+
+# Traceback (most recent call last):
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2719, in _process_plan
+#     raise ValueError(f"Parameter '{p.name}': {ex}")
+# ValueError: Parameter 'take_reading': The expression (<function trigger_and_read at 0x7ff0ae7ab640>) can not be evaluated with 'ast.literal_eval()': unsupported type of default value.
+
+# The above exception was the direct cause of the following exception:
+
+# Traceback (most recent call last):
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/worker.py", line 1130, in run
+#     epd = existing_plans_and_devices_from_nspace(nspace=self._re_namespace)
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2900, in existing_plans_and_devices_from_nspace
+#     existing_plans = _prepare_plans(plans_in_nspace, existing_devices=existing_devices)
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2786, in _prepare_plans
+#     return {
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2787, in <dictcomp>
+#     k: _process_plan(v, existing_devices=existing_devices, existing_plans=plan_names) for k, v in plans.items()
+#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2764, in _process_plan
+#     raise ValueError(f"Failed to create description of plan '{plan.__name__}': {ex}") from ex
+# ValueError: Failed to create description of plan 'one_1d_step': Parameter 'take_reading': The expression (<function trigger_and_read at 0x7ff0ae7ab640>) can not be evaluated with 'ast.literal_eval()': unsupported type of default value.
+
+
 from bluesky.preprocessors import finalize_wrapper
 from bluesky.preprocessors import subs_wrapper
 from bluesky.utils import short_uid as _short_uid

--- a/startup/92-optimization.py
+++ b/startup/92-optimization.py
@@ -122,7 +122,11 @@ if auto_alignment_mode():  # defined in 00-startup.py
         toroidal_mirror.ush,
         toroidal_mirror.dsh,
     ]
-    dofs = np.array([kbv.ush, kbv.dsh, kbh.ush, kbh.dsh])
+    kb_dofs = np.array([kbv.ush, kbv.dsh, kbh.ush, kbh.dsh])
+
+    ssa_dofs = np.array([ssa.inboard, ssa.outboard])
+
+    toroid_dofs = np.array([toroidal_mirror.usy, toroidal_mirror.dsy, toroidal_mirror.ush, toroidal_mirror.dsh])
     # dofs = [kbv.ush, kbv.dsh, kbh.ush, kbh.dsh, toroidal_mirror.usy, toroidal_mirror.dsy, toroidal_mirror.ush, toroidal_mirror.dsh]
 
     rel_bounds = {
@@ -130,21 +134,30 @@ if auto_alignment_mode():  # defined in 00-startup.py
         "kbv_dsh": [-1e-1, +1e-1],
         "kbh_ush": [-1e-1, +1e-1],
         "kbh_dsh": [-1e-1, +1e-1],
+        "ssa_inboard": [-1e-1, +1e-1],
+        "ssa_outboard": [-1e-1, +1e-1],
         "toroidal_mirror_ush": [-1e-1, +1e-1],
         "toroidal_mirror_dsh": [-1e-1, +1e-1],
         "toroidal_mirror_usy": [-1e-1, +1e-1],
         "toroidal_mirror_dsy": [-1e-1, +1e-1],
     }
     fid_params = {
-        "kbv_ush": -0.0500010,
-        "kbv_dsh": -0.0500010,
-        "kbh_ush": 2.2650053,
-        "kbh_dsh": 3.3120017,
-        "toroidal_mirror_ush": -9.515,
-        "toroidal_mirror_dsh": -3.92,
-        "toroidal_mirror_usy": -6.284,
-        "toroidal_mirror_dsy": -9.2575,
+        "kbv_ush": 0.050,
+        "kbv_dsh": 0.030,
+        "kbh_ush": 2.485,
+        "kbh_dsh": 3.532,
+        "ssa_inboard": -0.3700,
+        "ssa_outboard": -0.1705,
+        "toroidal_mirror_ush": -9.530,
+        "toroidal_mirror_dsh": -3.900,
+        "toroidal_mirror_usy": -6.280,
+        "toroidal_mirror_dsy": -9.160,
     }
-    hard_bounds = np.r_[[fid_params[dof.name] + 2 * np.array(rel_bounds[dof.name]) for dof in dofs]]
+    # hard_bounds = np.r_[[fid_params[dof.name] + 2 * np.array(rel_bounds[dof.name]) for dof in dofs]]
 
     # gpo = gp.Optimizer(init_scheme='quasi-random', n_init=4, run_engine=RE, db=db, shutter=psh, detector=vstream, detector_type='image', dofs=dofs, dof_bounds=hard_bounds, fitness_model='max_sep_density', training_iter=256, verbose=True)
+
+    dofs = kb_dofs[:2]
+    hard_bounds = np.r_[[fid_params[dof.name] + 1 * np.array(rel_bounds[dof.name]) for dof in dofs]]
+
+    from bloptools import gp

--- a/startup/92-optimization.py
+++ b/startup/92-optimization.py
@@ -130,16 +130,16 @@ if auto_alignment_mode():  # defined in 00-startup.py
     # dofs = [kbv.ush, kbv.dsh, kbh.ush, kbh.dsh, toroidal_mirror.usy, toroidal_mirror.dsy, toroidal_mirror.ush, toroidal_mirror.dsh]
 
     rel_bounds = {
-        "kbv_ush": [-1e-1, +1e-1],
-        "kbv_dsh": [-1e-1, +1e-1],
-        "kbh_ush": [-1e-1, +1e-1],
-        "kbh_dsh": [-1e-1, +1e-1],
+        "kbv_ush": [-5e-2, +5e-2],
+        "kbv_dsh": [-5e-2, +5e-2],
+        "kbh_ush": [-5e-2, +5e-2],
+        "kbh_dsh": [-5e-2, +5e-2],
         "ssa_inboard": [-1e-1, +1e-1],
         "ssa_outboard": [-1e-1, +1e-1],
-        "toroidal_mirror_ush": [-1e-1, +1e-1],
-        "toroidal_mirror_dsh": [-1e-1, +1e-1],
-        "toroidal_mirror_usy": [-1e-1, +1e-1],
-        "toroidal_mirror_dsy": [-1e-1, +1e-1],
+        "toroidal_mirror_ush": [-1e-2, +1e-2],
+        "toroidal_mirror_dsh": [-1e-2, +1e-2],
+        "toroidal_mirror_usy": [-1e-2, +1e-2],
+        "toroidal_mirror_dsy": [-1e-2, +1e-2],
     }
     fid_params = {
         "kbv_ush": 0.050,


### PR DESCRIPTION
We tried `bluesky-queueserver`, but encountered an issue with standard bluesky plan stubs (e.g., `one_1d_step`).