### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Test IPython beamline profiles
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Run Integration Tests Against Beamline Profiles
         uses: NSLS2/gha-beamline-integration-test@2025-1.0-test


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
